### PR TITLE
Workaround for bug in Jekyll 3.9.4

### DIFF
--- a/_pages/404.md
+++ b/_pages/404.md
@@ -1,7 +1,6 @@
 ---
 title: "Page Not Found"
 layout: single
-excerpt: "Page not found. Your pixels are in another canvas."
 sitemap: false
 permalink: /404.html
 ---


### PR DESCRIPTION
There's a bug in Jekyll version 3.9.4 (recently released), something to do with the Excerpt tag in the metadata.

According to the workaround, removing the Excerpt tag from the 404.md, about.md, and non-menu-page.md should work. The error in my build file points to a problem with 404.md (see below).

Bug details: https://github.com/jekyll/jekyll/issues/9544

Workaround: https://github.com/academicpages/academicpages.github.io/issues/1878

Error in the build file: 
`/usr/local/bundle/gems/jekyll-3.9.4/lib/jekyll/excerpt.rb:135:in `extract_excerpt': undefined method `excerpt_separator' for #<Jekyll::Page @name="404.md"> (NoMethodError)`