### PR TITLE
Hilton tod patch2 20240210 bug jekyll ver 3.9.4

### DIFF
--- a/_pages/allyship.md
+++ b/_pages/allyship.md
@@ -2,7 +2,6 @@
 layout: single
 permalink: /allyship/
 title: "Allyship"
-excerpt: ""
 fullwidth: true
 author_profile: true
 ---

--- a/_pages/facts.md
+++ b/_pages/facts.md
@@ -2,7 +2,6 @@
 layout: single
 permalink: /facts/
 title: "Are your facts really true?"
-excerpt: ""
 fullwidth: true
 author_profile: true
 ---

--- a/_pages/links.md
+++ b/_pages/links.md
@@ -2,7 +2,6 @@
 layout: archive
 permalink: /links/
 title: "Links"
-excerpt: ""
 ads: false
 fullwidth: true
 author_profile: false

--- a/_pages/resume.md
+++ b/_pages/resume.md
@@ -2,7 +2,6 @@
 layout: single
 permalink: /resume/
 title: "Resume"
-excerpt: ""
 fullwidth: true
 author_profile: true
 ---

--- a/_pages/square.md
+++ b/_pages/square.md
@@ -2,7 +2,6 @@
 layout: archive
 permalink: /square/
 title: ""
-excerpt: ""
 ads: false
 fullwidth: true
 author_profile: false


### PR DESCRIPTION
There's a bug in Jekyll version 3.9.4 (recently released), something to do with the Excerpt tag in the metadata.

According to the workaround, removing the Excerpt tag from the 404.md, about.md, and non-menu-page.md should work. The error in my first build points to a problem with 404.md (see below), but after fixing that the error went to allyship.md. I think the Excerpt tag needs to be removed from all files under the _pages directory. 

Bug details: https://github.com/jekyll/jekyll/issues/9544

Workaround: https://github.com/academicpages/academicpages.github.io/issues/1878

Error in the build file first time:
/usr/local/bundle/gems/jekyll-3.9.4/lib/jekyll/excerpt.rb:135:in extract_excerpt': undefined method excerpt_separator' for #<Jekyll::Page @name="404.md"> (NoMethodError)

Error in the build file second time:
/usr/local/bundle/gems/jekyll-3.9.4/lib/jekyll/excerpt.rb:135:in `extract_excerpt': undefined method `excerpt_separator' for #<Jekyll::Page @name="allyship.md"> (NoMethodError)
