### PR TITLE
Hilton tod patch 3 20240210 jeykyll bug ver 3.9.4

### DIFF
--- a/_pages/reads.md
+++ b/_pages/reads.md
@@ -2,12 +2,13 @@
 layout: archive
 permalink: /reads/
 title: "Reads"
-excerpt: "Books I've read. Not quite reviews, more like thoughts and notes. See my **[reading list](/reads/books/)**."
 fullwidth: true
 author_profile: true
 ---
 
 {{ page.excerpt | markdownify }}
+
+Books I've read. Not quite reviews, more like thoughts and notes. See my **[reading list](/reads/books/)**.
 
 ---
 

--- a/_pages/technicalwriting.md
+++ b/_pages/technicalwriting.md
@@ -2,8 +2,6 @@
 layout: archive
 permalink: /technicalwriting/
 title: "Portfolio"
-excerpt: "I like to write. I like technology. I like to help. Technical 
-writing combines those passions. See my **[resume here](/resume/)**."
 author_profile: true
 feature:
   visible: false
@@ -12,6 +10,9 @@ feature:
 ---
 
 {{ page.excerpt | markdownify }}
+
+I like to write. I like technology. I like to help. Technical 
+writing combines those passions. See my **[resume here](/resume/)**.
 
 ---
 

--- a/_pages/words.md
+++ b/_pages/words.md
@@ -2,13 +2,14 @@
 layout: archive
 permalink: /words/
 title: "Words"
-excerpt: "Getting the words out. My writings on topics ranging from parenting to technology to just about anything that pops into my head."
 ads: false
 fullwidth: true
 author_profile: true
 ---
 
 {{ page.excerpt | markdownify }}
+
+Getting the words out. My writings on topics ranging from parenting to technology to just about anything that pops into my head.
 
 ---
 


### PR DESCRIPTION
There's a bug in Jekyll version 3.9.4 (recently released), something to do with the Excerpt tag in the metadata.

According to the workaround, removing the Excerpt tag from all files in the _pages directory allows it to work. I moved any text from the Excerpt tag down into the body of the file.

Bug details: https://github.com/jekyll/jekyll/issues/9544

Workaround: https://github.com/academicpages/academicpages.github.io/issues/1878

Error in the build file first time:
/usr/local/bundle/gems/jekyll-3.9.4/lib/jekyll/excerpt.rb:135:in extract_excerpt': undefined method excerpt_separator' for #<Jekyll::Page @name="404.md"> (NoMethodError)

Error in the build file second time:
/usr/local/bundle/gems/jekyll-3.9.4/lib/jekyll/excerpt.rb:135:in extract_excerpt': undefined method excerpt_separator' for #<Jekyll::Page @name="allyship.md"> (NoMethodError)